### PR TITLE
Fix reading MIDI events with UTF-8 locale

### DIFF
--- a/nativeapp/midiinputprovider.pl
+++ b/nativeapp/midiinputprovider.pl
@@ -67,7 +67,7 @@ sub ConnectMidi {
     die("Invalid device name in ConnectMidi: $device\n");
   }
 
-  open(my $fh, '<', "/dev/snd/$device") or die("Can't open MIDI: $!\n");
+  open(my $fh, '<:raw', "/dev/snd/$device") or die("Can't open MIDI: $!\n");
   while(read($fh, my $byte, 1)) {
     $byte = ord($byte); # Convert character to byte
 


### PR DESCRIPTION
On my system Perl (v5.30.1) reports such errors as: Malformed UTF-8 character: \x80 (unexpected continuation byte 0x80, with no preceding start byte) and midiinputprovider does not provide MIDI events.

(Switching from `ord` to `unpack` does not help: Perl continues to report malformed UTF-8 character.)